### PR TITLE
Don't do a head request in connect

### DIFF
--- a/sbt-gcs-plugin/.scalafmt.conf
+++ b/sbt-gcs-plugin/.scalafmt.conf
@@ -2,7 +2,10 @@ version = 3.8.1
 preset = default
 lineEndings = unix
 maxColumn = 120
-docstrings = JavaDoc
+
+runner {
+    dialect = scala212
+}
 
 align {
   preset = more
@@ -11,9 +14,6 @@ align {
   arrowEnumeratorGenerator = true
 }
 
-newlines {
-  alwaysBeforeTopLevelStatements = true
-}
 continuationIndent {
   defnSite = 4
 }
@@ -32,5 +32,4 @@ trailingCommas = never
 
 verticalMultiline {
   atDefnSite = false
-  newlineBeforeImplicitKW = true
 }

--- a/sbt-gcs-plugin/src/main/scala/org/latestbit/sbt/gcs/artifactregistry/GcsArtifactRegistryUrlConnection.scala
+++ b/sbt-gcs-plugin/src/main/scala/org/latestbit/sbt/gcs/artifactregistry/GcsArtifactRegistryUrlConnection.scala
@@ -58,7 +58,7 @@ class GcsArtifactRegistryUrlConnection( googleHttpRequestFactory: HttpRequestFac
         }
         if (responseCode < 400) {
           try {
-            logger.info( s"Receiving an artifact from url: ${url}." )
+            logger.debug( s"Receiving an artifact from url: ${url}." )
             val httpRequest = googleHttpRequestFactory.buildGetRequest( genericUrl )
 
             val httpResponse = appendHeadersBeforeConnect( httpRequest ).execute()

--- a/sbt-gcs-plugin/src/main/scala/org/latestbit/sbt/gcs/artifactregistry/GcsArtifactRegistryUrlConnection.scala
+++ b/sbt-gcs-plugin/src/main/scala/org/latestbit/sbt/gcs/artifactregistry/GcsArtifactRegistryUrlConnection.scala
@@ -42,20 +42,10 @@ class GcsArtifactRegistryUrlConnection( googleHttpRequestFactory: HttpRequestFac
     // when the connection has already been opened the call is ignored.
     if (!connected) {
       connectedWithHeaders = new HttpHeaders()
-      try {
-        super.getRequestProperties.asScala.foreach { case ( header, headerValues ) =>
-          connectedWithHeaders.set( header, headerValues )
-        }
-        logger.debug( s"Checking artifact at url: ${url}." )
-        val httpRequest =
-          googleHttpRequestFactory.buildHeadRequest( genericUrl )
-        connected = httpRequest.execute().isSuccessStatusCode
-      } catch {
-        case ex: HttpResponseException => {
-          responseCode = ex.getStatusCode
-          responseMessage = ex.getStatusMessage
-        }
+      super.getRequestProperties.asScala.foreach { case ( header, headerValues ) =>
+        connectedWithHeaders.set( header, headerValues )
       }
+      connected = true
     }
   }
 


### PR DESCRIPTION
### Problem

When fetching an artifact two requests are done against Google Artifact Registry, one in the `connect()` method and one in the `getInputStream` method. This will double the load on GAR and of course also counts against the request quota. When looking at upstream requests in a virtual repository in GAR all HEAD requests in the `connect()` methods results in GET requests against the upstreams until the requested artifact is found. 

### Solution

The HEAD request is not necessary as the error will occur at the `getInputStream` if there is a problem with downloading the artifact so by remove this request there will be a performance boost. (#71)

Also includes a fix for the redundant log when downloading. (#70)
 