### PR TITLE
Move Credentials to UrlHandler

### DIFF
--- a/sbt-gcs-plugin/src/main/scala/org/latestbit/sbt/gcs/GcsPlugin.scala
+++ b/sbt-gcs-plugin/src/main/scala/org/latestbit/sbt/gcs/GcsPlugin.scala
@@ -15,16 +15,8 @@
  */
 package org.latestbit.sbt.gcs
 
-import com.google.auth.oauth2.GoogleCredentials
-import com.google.common.collect.ImmutableList
 import sbt.Keys._
 import sbt._
-
-import com.google.auth.oauth2.AccessToken
-import java.io.FileInputStream
-import java.nio.file.Path
-import scala.collection.JavaConverters._
-import scala.util.{ Failure, Success, Try }
 
 object GcsPlugin extends AutoPlugin {
   override def trigger = allRequirements
@@ -41,78 +33,15 @@ object GcsPlugin extends AutoPlugin {
   private val gcsPluginTaskInits = Seq(
     onLoad in Global := ( onLoad in Global ).value.andThen { state =>
       implicit val logger: Logger = state.log
-      Try {
-        val googleCredentials = if ( googleCredentialsDisable.value ) {
-          logger.debug( s"Google Application Default Credentials lookup is disabled" )
-          None
-        } else {
-          Some(
-            loadGoogleCredentials(
-              googleCredentialsFile.value.map( _.toPath )
-            )
-          )
-        }
-        GcsUrlHandlerFactory.install( googleCredentials, gcsPublishFilePolicy.value )
-        logger.info(
-          s"Google GCS/Artifact Registry support is enabled. Google Credentials: ${googleCredentials.map( _ => "identified" ).getOrElse( "unused" )} "
-        )
-      } match {
-        case Success( _ )   => state
-        case Failure( err ) => {
-          logger.err(
-            s"Unable to find/initialise google credentials: ${err}. Publishing/resolving artifacts from GCP is disabled."
-          )
-          state
-        }
-      }
+      GcsUrlHandlerFactory.install(
+        googleCredentialsFile    = googleCredentialsFile.value,
+        googleCredentialsDisable = googleCredentialsDisable.value,
+        gcsPublishFilePolicy     = gcsPublishFilePolicy.value
+      )
+      logger.info( s"Google GCS/Artifact Registry support is enabled." )
+      state
     }
   )
 
   override def globalSettings: Seq[Setting[_]] = gcsPluginTaskInits ++ gcsPluginDefaultSettings ++ super.globalSettings
-
-  private def loadGoogleCredentials(
-      gcsCredentialsFilePath: Option[Path]
-  )( implicit logger: Logger ): GoogleCredentials = {
-    val scopes: java.util.Collection[String] =
-      ImmutableList.copyOf( GoogleCredentialsScopes.asJavaCollection.iterator() )
-    gcsCredentialsFilePath
-      .orElse( lookupGoogleCredentialsInSbtDir() )
-      .map { path =>
-        logger.debug( s"Loading Google credentials from: ${path.toAbsolutePath.toString}" )
-        GoogleCredentials
-          .fromStream( new FileInputStream( path.toFile ) )
-          .createScoped( scopes )
-      }
-      .orElse {
-        Option( System.getenv( "GOOGLE_OAUTH_ACCESS_TOKEN" ) ).map( accessToken =>
-          GoogleCredentials
-            .create( AccessToken.newBuilder().setTokenValue( accessToken ).build() )
-            .createScoped( scopes )
-        )
-      }
-      .getOrElse {
-        logger.debug( s"Loading default Google credentials" )
-        GoogleCredentials.getApplicationDefault().createScoped( scopes )
-      }
-
-  }
-
-  private def lookupGoogleCredentialsInSbtDir(): Option[Path] = {
-    Try( Option( System.getProperty( "user.home" ) ) ).toOption.flatten.flatMap { userHomeDir =>
-      val sbtUserRootDir = new File( userHomeDir, ".sbt" )
-      if ( sbtUserRootDir.exists() && sbtUserRootDir.isDirectory ) {
-        val googleAccountInSbt = new File( sbtUserRootDir, "gcs-resolver-google-account.json" )
-        if ( googleAccountInSbt.exists() && googleAccountInSbt.isFile ) {
-          Some( googleAccountInSbt.toPath )
-        } else
-          None
-      } else
-        None
-    }
-  }
-
-  private final val GoogleCredentialsScopes: Set[String] = Set(
-    "https://www.googleapis.com/auth/cloud-platform",
-    "https://www.googleapis.com/auth/cloud-platform.read-only"
-  )
 }

--- a/sbt-gcs-plugin/src/main/scala/org/latestbit/sbt/gcs/GcsPlugin.scala
+++ b/sbt-gcs-plugin/src/main/scala/org/latestbit/sbt/gcs/GcsPlugin.scala
@@ -41,15 +41,16 @@ object GcsPlugin extends AutoPlugin {
           googleCredentialsDisable = googleCredentialsDisable.value,
           gcsPublishFilePolicy = gcsPublishFilePolicy.value
         )
+        logger.info( s"Google GCS/Artifact Registry support is enabled." )
       } match {
-        case Success( _ ) =>
-          logger.info( s"Google GCS/Artifact Registry support is enabled." )
-        case Failure( err ) =>
+        case Success( _ )   => state
+        case Failure( err ) => {
           logger.err(
             s"Unable to install GCS/Artifact Registry URL handlers: ${err}. Publishing/resolving artifacts from GCP is disabled."
           )
+          state
+        }
       }
-      state
     }
   )
 

--- a/sbt-gcs-plugin/src/main/scala/org/latestbit/sbt/gcs/GcsPlugin.scala
+++ b/sbt-gcs-plugin/src/main/scala/org/latestbit/sbt/gcs/GcsPlugin.scala
@@ -18,6 +18,8 @@ package org.latestbit.sbt.gcs
 import sbt.Keys._
 import sbt._
 
+import scala.util.{ Failure, Success, Try }
+
 object GcsPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
@@ -33,12 +35,20 @@ object GcsPlugin extends AutoPlugin {
   private val gcsPluginTaskInits = Seq(
     onLoad in Global := ( onLoad in Global ).value.andThen { state =>
       implicit val logger: Logger = state.log
-      GcsUrlHandlerFactory.install(
-        googleCredentialsFile    = googleCredentialsFile.value,
-        googleCredentialsDisable = googleCredentialsDisable.value,
-        gcsPublishFilePolicy     = gcsPublishFilePolicy.value
-      )
-      logger.info( s"Google GCS/Artifact Registry support is enabled." )
+      Try {
+        GcsUrlHandlerFactory.install(
+          googleCredentialsFile = googleCredentialsFile.value,
+          googleCredentialsDisable = googleCredentialsDisable.value,
+          gcsPublishFilePolicy = gcsPublishFilePolicy.value
+        )
+      } match {
+        case Success( _ ) =>
+          logger.info( s"Google GCS/Artifact Registry support is enabled." )
+        case Failure( err ) =>
+          logger.err(
+            s"Unable to install GCS/Artifact Registry URL handlers: ${err}. Publishing/resolving artifacts from GCP is disabled."
+          )
+      }
       state
     }
   )

--- a/sbt-gcs-plugin/src/main/scala/org/latestbit/sbt/gcs/GcsUrlHandlerFactory.scala
+++ b/sbt-gcs-plugin/src/main/scala/org/latestbit/sbt/gcs/GcsUrlHandlerFactory.scala
@@ -34,8 +34,8 @@ import scala.util.Try
 
 object GcsUrlHandlerFactory {
 
-  /** Registers gs:// and artifactregistry:// URL handlers unconditionally.
-    * Credentials are loaded lazily on the first actual network request.
+  /** Registers gs:// and artifactregistry:// URL handlers unconditionally. Credentials are loaded lazily on the first
+    * actual network request.
     */
   def install(
       googleCredentialsFile: Option[File],
@@ -144,5 +144,6 @@ object GcsUrlHandlerFactory {
       .getOrElse {
         httpTransport.createRequestFactory()
       }
+
   }
 }

--- a/sbt-gcs-plugin/src/main/scala/org/latestbit/sbt/gcs/GcsUrlHandlerFactory.scala
+++ b/sbt-gcs-plugin/src/main/scala/org/latestbit/sbt/gcs/GcsUrlHandlerFactory.scala
@@ -18,29 +18,43 @@ package org.latestbit.sbt.gcs
 import com.google.api.client.http.HttpRequestFactory
 import com.google.api.client.http.javanet.NetHttpTransport
 import com.google.auth.http.{ HttpCredentialsAdapter, HttpTransportFactory }
-import com.google.auth.oauth2.GoogleCredentials
+import com.google.auth.oauth2.{ AccessToken, GoogleCredentials }
+import com.google.common.collect.ImmutableList
 import com.google.cloud.storage.StorageOptions
 import org.apache.ivy.util.url.{ URLHandlerDispatcher, URLHandlerRegistry }
 import org.latestbit.sbt.gcs.artifactregistry.{ GcsArtifactRegistryIvyUrlHandler, GcsArtifactRegistryUrlHandler }
 import org.latestbit.sbt.gcs.gs.{ GcsIvyUrlHandler, GcsUrlHandler }
-import sbt.Logger
+import sbt.{ File, Logger }
 
+import java.io.FileInputStream
 import java.net.{ URI, URL }
+import java.nio.file.Path
+import scala.collection.JavaConverters._
+import scala.util.Try
 
 object GcsUrlHandlerFactory {
 
-  /** To install if it isn't already installed gs:// URLs handler without throwing a java.net.MalformedURLException.
+  /** Registers gs:// and artifactregistry:// URL handlers unconditionally.
+    * Credentials are loaded lazily on the first actual network request.
     */
-  def install( credentials: Option[GoogleCredentials], gcsPublishFilePolicy: GcsPublishFilePolicy )( implicit
-      logger: Logger
-  ) = {
-
-    val gcsStorage = {
+  def install(
+      googleCredentialsFile: Option[File],
+      googleCredentialsDisable: Boolean,
+      gcsPublishFilePolicy: GcsPublishFilePolicy
+  )( implicit logger: Logger ) = {
+    lazy val credentials: Option[GoogleCredentials] =
+      if ( googleCredentialsDisable ) {
+        logger.debug( s"Google Application Default Credentials lookup is disabled" )
+        None
+      } else {
+        Some( loadGoogleCredentials( googleCredentialsFile.map( _.toPath ) ) )
+      }
+    lazy val gcsStorage = {
       val builder = StorageOptions.newBuilder()
       credentials.foreach( builder.setCredentials( _ ) )
       builder.build().getService
     }
-    val googleHttpRequestFactory = createHttpRequestFactory( credentials )
+    lazy val googleHttpRequestFactory = createHttpRequestFactory( credentials )
 
     // Install gs:// handler for JDK
     try {
@@ -72,6 +86,51 @@ object GcsUrlHandlerFactory {
     dispatcher.setDownloader( "artifactregistry", new GcsArtifactRegistryIvyUrlHandler( googleHttpRequestFactory ) )
   }
 
+  private def loadGoogleCredentials(
+      gcsCredentialsFilePath: Option[Path]
+  )( implicit logger: Logger ): GoogleCredentials = {
+    val scopes: java.util.Collection[String] =
+      ImmutableList.copyOf( GoogleCredentialsScopes.asJavaCollection.iterator() )
+    gcsCredentialsFilePath
+      .orElse( lookupGoogleCredentialsInSbtDir() )
+      .map { path =>
+        logger.debug( s"Loading Google credentials from: ${path.toAbsolutePath.toString}" )
+        GoogleCredentials
+          .fromStream( new FileInputStream( path.toFile ) )
+          .createScoped( scopes )
+      }
+      .orElse {
+        Option( System.getenv( "GOOGLE_OAUTH_ACCESS_TOKEN" ) ).map( accessToken =>
+          GoogleCredentials
+            .create( AccessToken.newBuilder().setTokenValue( accessToken ).build() )
+            .createScoped( scopes )
+        )
+      }
+      .getOrElse {
+        logger.debug( s"Loading default Google credentials" )
+        GoogleCredentials.getApplicationDefault().createScoped( scopes )
+      }
+  }
+
+  private def lookupGoogleCredentialsInSbtDir(): Option[Path] = {
+    Try( Option( System.getProperty( "user.home" ) ) ).toOption.flatten.flatMap { userHomeDir =>
+      val sbtUserRootDir = new java.io.File( userHomeDir, ".sbt" )
+      if ( sbtUserRootDir.exists() && sbtUserRootDir.isDirectory ) {
+        val googleAccountInSbt = new java.io.File( sbtUserRootDir, "gcs-resolver-google-account.json" )
+        if ( googleAccountInSbt.exists() && googleAccountInSbt.isFile ) {
+          Some( googleAccountInSbt.toPath )
+        } else
+          None
+      } else
+        None
+    }
+  }
+
+  private final val GoogleCredentialsScopes: Set[String] = Set(
+    "https://www.googleapis.com/auth/cloud-platform",
+    "https://www.googleapis.com/auth/cloud-platform.read-only"
+  )
+
   private final val httpTransportFactory: HttpTransportFactory = { () =>
     new NetHttpTransport()
   }
@@ -85,6 +144,5 @@ object GcsUrlHandlerFactory {
       .getOrElse {
         httpTransport.createRequestFactory()
       }
-
   }
 }

--- a/sbt-gcs-plugin/src/main/scala/org/latestbit/sbt/gcs/artifactregistry/GcsArtifactRegistryIvyUrlHandler.scala
+++ b/sbt-gcs-plugin/src/main/scala/org/latestbit/sbt/gcs/artifactregistry/GcsArtifactRegistryIvyUrlHandler.scala
@@ -26,8 +26,9 @@ import java.nio.file.Files
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 
-class GcsArtifactRegistryIvyUrlHandler( googleHttpRequestFactory: HttpRequestFactory )( implicit logger: Logger )
+class GcsArtifactRegistryIvyUrlHandler( googleHttpRequestFactory: => HttpRequestFactory )( implicit logger: Logger )
     extends URLHandler {
+  private lazy val factory = googleHttpRequestFactory
 
   override def isReachable( url: URL ): Boolean = getURLInfo( url ).isReachable
 
@@ -43,7 +44,7 @@ class GcsArtifactRegistryIvyUrlHandler( googleHttpRequestFactory: HttpRequestFac
 
   override def getURLInfo( url: URL ): URLHandler.URLInfo = {
     val genericUrl   = GcsArtifactRegistryGenericUrlFactory.createFromUrl( url )
-    val httpRequest  = googleHttpRequestFactory.buildHeadRequest( genericUrl ).setThrowExceptionOnExecuteError( false )
+    val httpRequest  = factory.buildHeadRequest( genericUrl ).setThrowExceptionOnExecuteError( false )
     val httpResponse = httpRequest.execute()
     GcsArtifactRegistryIvyUrlInfo(
       available = httpResponse.isSuccessStatusCode,
@@ -59,7 +60,7 @@ class GcsArtifactRegistryIvyUrlHandler( googleHttpRequestFactory: HttpRequestFac
 
   override def openStream( url: URL ): InputStream = {
     val genericUrl   = GcsArtifactRegistryGenericUrlFactory.createFromUrl( url )
-    val httpRequest  = googleHttpRequestFactory.buildGetRequest( genericUrl )
+    val httpRequest  = factory.buildGetRequest( genericUrl )
     val httpResponse = httpRequest.execute()
     httpResponse.getContent
   }

--- a/sbt-gcs-plugin/src/main/scala/org/latestbit/sbt/gcs/artifactregistry/GcsArtifactRegistryUrlHandler.scala
+++ b/sbt-gcs-plugin/src/main/scala/org/latestbit/sbt/gcs/artifactregistry/GcsArtifactRegistryUrlHandler.scala
@@ -20,10 +20,11 @@ import sbt.Logger
 
 import java.net.{ URL, URLConnection, URLStreamHandler }
 
-class GcsArtifactRegistryUrlHandler( googleHttpRequestFactory: HttpRequestFactory )( implicit logger: Logger )
+class GcsArtifactRegistryUrlHandler( googleHttpRequestFactory: => HttpRequestFactory )( implicit logger: Logger )
     extends URLStreamHandler {
+  private lazy val factory = googleHttpRequestFactory
 
   override def openConnection( url: URL ): URLConnection = {
-    new GcsArtifactRegistryUrlConnection( googleHttpRequestFactory, url )
+    new GcsArtifactRegistryUrlConnection( factory, url )
   }
 }

--- a/sbt-gcs-plugin/src/main/scala/org/latestbit/sbt/gcs/gs/GcsIvyUrlHandler.scala
+++ b/sbt-gcs-plugin/src/main/scala/org/latestbit/sbt/gcs/gs/GcsIvyUrlHandler.scala
@@ -26,8 +26,9 @@ import java.io.{ File, FileInputStream, InputStream }
 import java.net.URL
 import java.nio.channels.Channels
 
-class GcsIvyUrlHandler( gcsStorage: Storage, gcsPublishFilePolicy: GcsPublishFilePolicy )( implicit logger: Logger )
+class GcsIvyUrlHandler( gcsStorage: => Storage, gcsPublishFilePolicy: GcsPublishFilePolicy )( implicit logger: Logger )
     extends URLHandler {
+  private lazy val storage = gcsStorage
 
   override def isReachable( url: URL ): Boolean = urlToGcsIvyUrlInfo( url ).available
 
@@ -46,7 +47,7 @@ class GcsIvyUrlHandler( gcsStorage: Storage, gcsPublishFilePolicy: GcsPublishFil
   override def getURLInfo( url: URL, timeout: Int ): URLHandler.URLInfo = getURLInfo( url )
 
   override def openStream( url: URL ): InputStream = {
-    Option( gcsStorage.get( GcsUrlConnection.toBlobId( url ) ) ).map { blob =>
+    Option( storage.get( GcsUrlConnection.toBlobId( url ) ) ).map { blob =>
       Channels.newInputStream( blob.reader() )
     }.orNull
   }
@@ -54,7 +55,7 @@ class GcsIvyUrlHandler( gcsStorage: Storage, gcsPublishFilePolicy: GcsPublishFil
   override def download( src: URL, dest: File, l: CopyProgressListener ): Unit = {
     val event = new CopyProgressEvent()
     Option( l ).foreach( _.start( event ) )
-    Option( gcsStorage.get( GcsUrlConnection.toBlobId( src ) ) )
+    Option( storage.get( GcsUrlConnection.toBlobId( src ) ) )
       .foreach { blob =>
         blob.downloadTo( dest.toPath )
       }
@@ -64,7 +65,7 @@ class GcsIvyUrlHandler( gcsStorage: Storage, gcsPublishFilePolicy: GcsPublishFil
   override def upload( src: File, dest: URL, l: CopyProgressListener ): Unit = {
     val bucketName  = dest.getHost
     val destination = dest.getPath.drop( 1 )
-    Option( gcsStorage.get( bucketName ) ) match {
+    Option( storage.get( bucketName ) ) match {
       case Some( gcsBucket ) => {
         logger.info(
           s"Publishing GCS artifact to '${dest}'..."
@@ -97,7 +98,7 @@ class GcsIvyUrlHandler( gcsStorage: Storage, gcsPublishFilePolicy: GcsPublishFil
   override def setRequestMethod( requestMethod: Int ): Unit = ()
 
   private def urlToGcsIvyUrlInfo( url: URL ): GcsIvyUrlInfo = {
-    Option( gcsStorage.get( GcsUrlConnection.toBlobId( url ) ) )
+    Option( storage.get( GcsUrlConnection.toBlobId( url ) ) )
       .map { blob =>
         GcsIvyUrlInfo(
           available = true,

--- a/sbt-gcs-plugin/src/main/scala/org/latestbit/sbt/gcs/gs/GcsUrlHandler.scala
+++ b/sbt-gcs-plugin/src/main/scala/org/latestbit/sbt/gcs/gs/GcsUrlHandler.scala
@@ -20,9 +20,10 @@ import sbt.Logger
 
 import java.net.{ URL, URLConnection, URLStreamHandler }
 
-class GcsUrlHandler( gcsStorage: Storage )( implicit logger: Logger ) extends URLStreamHandler {
+class GcsUrlHandler( gcsStorage: => Storage )( implicit logger: Logger ) extends URLStreamHandler {
+  private lazy val storage = gcsStorage
 
   override def openConnection( url: URL ): URLConnection = {
-    new GcsUrlConnection( gcsStorage, url )
+    new GcsUrlConnection( storage, url )
   }
 }


### PR DESCRIPTION
Fixes #135 

Without this change: For example,

```
sbt compile && GOOGLE_APPLICATION_CREDENTIALS=/dev/null sbt clean compile # fails
```

Even if the first `sbt compile` saves jars in the Coursier cache, the second `sbt` cannot use them because the GCS protocol handlers fail to register when credentials are unavailable.

With this change, the handlers are always registered regardless of credential availability, so the second command can use the Coursier cache.